### PR TITLE
Potential fix for code scanning alert no. 13: Uncontrolled data used in path expression

### DIFF
--- a/packages/api/src/routes/vuln.js
+++ b/packages/api/src/routes/vuln.js
@@ -20,10 +20,28 @@ router.get('/cmd', (req, res) => {
 });
 
 router.get('/file', (req, res) => {
-  const filePath = path.join(__dirname, req.query.name);
-  fs.readFile(filePath, 'utf8', (err, data) => {
-    if (err) return res.status(404).json({ error: err.message });
-    res.send(data);
+  const baseDir = __dirname;
+  const requestedPath = path.resolve(baseDir, String(req.query.name || ''));
+
+  fs.realpath(baseDir, (baseErr, realBaseDir) => {
+    if (baseErr) return res.status(500).json({ error: baseErr.message });
+
+    fs.realpath(requestedPath, (pathErr, realRequestedPath) => {
+      if (pathErr) return res.status(404).json({ error: pathErr.message });
+
+      const isInsideBase =
+        realRequestedPath === realBaseDir ||
+        realRequestedPath.startsWith(realBaseDir + path.sep);
+
+      if (!isInsideBase) {
+        return res.status(403).json({ error: 'Access denied' });
+      }
+
+      fs.readFile(realRequestedPath, 'utf8', (err, data) => {
+        if (err) return res.status(404).json({ error: err.message });
+        res.send(data);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/uday169/test-advanced-security/security/code-scanning/13](https://github.com/uday169/test-advanced-security/security/code-scanning/13)

To fix this safely without changing intended functionality, constrain file reads to a dedicated safe root and enforce that any requested file resolves inside that root after normalization/canonicalization.

Best fix in `packages/api/src/routes/vuln.js` (around lines 22–28):
1. Define a safe base directory for this route (for example, `__dirname` to preserve current behavior scope).
2. Resolve the user-supplied name against that base with `path.resolve`.
3. Canonicalize with `fs.realpath` (or sync equivalent) before use, then verify the canonical path starts with the canonical base path plus path separator (or equals base).
4. Reject invalid/outside paths with 403.
5. Only call `fs.readFile` on the validated canonical path.

No new dependency is required; use existing `fs` and `path`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
